### PR TITLE
First attempt at documenting surveys of interest

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,47 @@
 
 This repository hosts the research workstream of the [W3C WebDX Community Group](https://www.w3.org/community/webdx/), which focuses on coordinating _quantitative_ and _qualitative_ research efforts to better understand the major obstacles and gaps that developers face when using the Web.
 
-See [issues](https://github.com/web-platform-dx/developer-research/issues) for discussions and explorations of possible surveys.
+In practice, the WebDX Community Group regularly discusses surveys targeted at web developers to:
 
-The repository contains [results of past surveys](https://github.com/web-platform-dx/developer-research/tree/main/mdn-short-surveys), along with an interpretation of the results.
+- Converge on survey questions with survey proposers
+- Coordinate survey launch when applicable
+- Promote surveys
+- Coordinate the publication of survey results when applicable
+- Review and interpret survey results
+- Feed survey results into appropriate venue (e.g., [the Interop project](https://github.com/web-platform-tests/interop))
+
+## History of surveys tracked by the group
+
+| Survey                                                                      | Who/Where               | Date     | Answers | Raw results                                                     | Discussion                                                                                                 |
+|-----------------------------------------------------------------------------|-------------------------|----------|---------|-----------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| [State of HTML](https://stateofhtml.com/)                                   | Devographics            | Sep 2023 | 21889   | N/A                                                             | [Preliminary results](https://docs.google.com/presentation/d/1AVsalCAZVITkYZCLxux5D2LbwLukjjuH9cm-vZRYy-w) |
+| [State of CSS](https://stateofcss.com/)                                     | Devographics            | Jun 2023 | 9108    | N/A                                                             | [Results](https://2023.stateofcss.com/en-US/)                                                              |
+| [Web Security](mdn-short-surveys/2023-05-15-security-dx)                    | W3C workshop / MDN      | May 2023 | 297     | [CSV](mdn-short-surveys/results.csv)                            | [Interpretation](mdn-short-surveys/2023-05-15-security-dx/interpretation.md)                               |
+| [Web Components](mdn-short-surveys/2023-03-31-web-components)               | Web Components CG / MDN | Mar 2023 | 732     | [CSV](mdn-short-surveys/2023-03-31-web-components/results.csv)  | [Interpretation](mdn-short-surveys/2023-03-31-web-components/interpretation.md)                            |
+| [DevSat Survey](vendor-research/browser-support-matrix-survey.pdf)          | Google                  | Mar 2023 | 852     | N/A                                                             | [PDF slides](vendor-research/Web%20Dev%20Sat%20H1%202023.pdf)                                              |
+| [Browser Support Matrix](vendor-research/browser-support-matrix-survey.pdf) | Google                  | Nov 2022 | 233     | N/A                                                             | [PDF slides](vendor-research/browser-support-matrix-survey.pdf)                                            |
+| [Web Browsers](mdn-short-surveys/2022-10-24-browser-support)                | WebDX / MDN             | Oct 2022 | 964     | [CSV](mdn-short-surveys/2022-10-24-browser-support/results.csv) | [Interpretation](mdn-short-surveys/2022-10-24-browser-support/interpretation.md)                           |
+                                           |
+
+
+## Milestones
+
+An explicit goal of some of the recurring surveys is to inform [the Interop project](https://github.com/web-platform-tests/interop) on priorities. These surveys need to run in advance of the project's selection process, usually **in October**.
+
+More broadly speaking, important milestones for recurring surveys tracked by the WebDX Community Group are:
+
+| Survey                                        | Start | Review | Date | Results |
+|-----------------------------------------------|-------|--------|------|---------|
+| [State of HTML](https://stateofhtml.com/)     | Mar   | Jun    | Jul  | Oct     |
+| [State of CSS](https://stateofcss.com/)       | Feb   | May    | Jun  | Sep     |
+| [State of JavaScript](https://stateofjs.com/) | Aug   | Oct    | Nov  | Jan     |
+| DevSat survey H1                              | Dec   | Feb    | Mar  | Apr     |
+| DevSat survey H2                              | Jun   | Aug    | Sep  | Oct     |
+
+
+## Explorations of possible surveys
+
+See the list of open [issues](https://github.com/web-platform-dx/developer-research/issues) for discussions and explorations of possible surveys.
 
 
 ## Background


### PR DESCRIPTION
This adds two tables to the README:
- One table that contains the list of surveys discussed, reviewed, or prepared in the WebDX Community Group. That table is meant to provide a quick overview of the group's work with links to individual surveys. It will grow over time.
- One table that sets rough milestones for recurring surveys.

It would be useful to collect additional information about each survey, including links to issues that they gave birth to, e.g.,  in the Interop project, CSS WG, or wherever data was used. Not done here!